### PR TITLE
Fix for checking the domains present in the file.

### DIFF
--- a/src/platforms/win32.ts
+++ b/src/platforms/win32.ts
@@ -46,7 +46,13 @@ export default class WindowsPlatform implements Platform {
 
   async addDomainToHostFileIfMissing(domain: string) {
     let hostsFileContents = read(this.HOST_FILE_PATH, 'utf8');
-    if (!hostsFileContents.includes(domain)) {
+
+    const isPresent = hostsFileContents
+      .replace(/\s+/g, ' ')
+      .split(' ')
+      .filter(item => item === domain).length > 0;
+
+    if (!isPresent) {
       await sudo(`echo 127.0.0.1  ${ domain } >> ${ this.HOST_FILE_PATH }`);
     }
   }


### PR DESCRIPTION
If you have a domain a.b.c.d, it will not add domain b.c.d. because it is already contained based on the old logic.